### PR TITLE
Add init and check-config CLI commands. Rewrite config loading a bit

### DIFF
--- a/src/beneuro_data/config.py
+++ b/src/beneuro_data/config.py
@@ -1,6 +1,10 @@
 from pydantic.v1 import BaseSettings
 from pathlib import Path
-from dotenv import find_dotenv
+
+
+def _get_env_path():
+    package_path = Path(__file__).absolute().parent.parent.parent
+    return package_path / ".env"
 
 
 class Config(BaseSettings):
@@ -8,7 +12,13 @@ class Config(BaseSettings):
     REMOTE_PATH: Path
 
     class Config:
-        env_file = find_dotenv(".env")
+        env_file = _get_env_path()
 
 
-config = Config()
+def _load_config():
+    if not _get_env_path().exists():
+        raise FileNotFoundError(
+            "Config file not found. Run `bnd init-config` to create one."
+        )
+
+    return Config()


### PR DESCRIPTION
- `bnd init` checks if there is a .env file already present. If not, it prompts the user to enter the local and remote storage paths and saves it in a .env file
- `bnd check-config` checks if the paths stored in the config file have the required `raw` and `processed` folders

Rewrote where the config is loaded to handle the case where there is no config file present, but one still wants to use `bnd --help` -- to discover that `bnd init` exists for example.