### PR TITLE
Add CLI command self-update

### DIFF
--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -9,6 +9,7 @@ from beneuro_data.data_validation import validate_raw_session
 from beneuro_data.data_transfer import upload_raw_session
 from beneuro_data.video_renaming import rename_raw_videos_of_session
 from beneuro_data.config import _get_env_path, _load_config
+from beneuro_data.update_bnd import update_bnd
 
 
 app = typer.Typer()
@@ -413,6 +414,19 @@ def init():
         _check_root(config.REMOTE_PATH)
 
         print("[green]Config file created successfully.")
+
+
+@app.command()
+def self_update(
+    verbose: Annotated[
+        bool,
+        typer.Option(help="Print new commits that were pulled."),
+    ] = True,
+):
+    """
+    Update the bnd tool by pulling the latest commits from the repo's main branch.
+    """
+    update_bnd(print_new_commits=verbose)
 
 
 if __name__ == "__main__":

--- a/src/beneuro_data/update_bnd.py
+++ b/src/beneuro_data/update_bnd.py
@@ -1,0 +1,43 @@
+import subprocess
+from pathlib import Path
+
+from rich import print
+
+
+def _run_git_command(repo_path: str, command: list[str]) -> str:
+    """Run a git command in the specified repository and return its output"""
+    result = subprocess.run(
+        ["git", "-C", repo_path] + command, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise Exception(f"Git command failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def _get_new_commits(repo_path: str) -> list[str]:
+    """Check for new commits from origin/main"""
+    # Fetch the latest changes from the remote repository
+    _run_git_command(repo_path, ["fetch"])
+
+    # Check if origin/main has new commits compared to the local branch
+    new_commits = _run_git_command(repo_path, ["log", "HEAD..origin/main", "--oneline"])
+
+    return new_commits.split("\n")
+
+
+def update_bnd(print_new_commits: bool = False):
+    package_path = Path(__file__).absolute().parent.parent.parent
+
+    new_commits = _get_new_commits(package_path)
+
+    if len(new_commits) > 0:
+        print("New commits found, pulling changes...")
+        _run_git_command(package_path, ["pull", "origin", "main"])
+        print("Package updated successfully.")
+
+        if print_new_commits:
+            print("New commits:")
+            for commit in new_commits:
+                print(f" - {commit}")
+    else:
+        print("Package appears to be up to date, no new commits found.")


### PR DESCRIPTION
Instead of experimenters having to find the installation directory and doing git pull every time there's an update, just have a command that does it.

Fixes #24 