### PR TITLE
Run poetry install on update

### DIFF
--- a/src/beneuro_data/update_bnd.py
+++ b/src/beneuro_data/update_bnd.py
@@ -20,9 +20,7 @@ def _get_new_commits(repo_path: str) -> list[str]:
     _run_git_command(repo_path, ["fetch"])
 
     # Check if origin/main has new commits compared to the local branch
-    new_commits = _run_git_command(
-        repo_path, ["log", "HEAD..origin/poetry_install_on_update", "--oneline"]
-    )
+    new_commits = _run_git_command(repo_path, ["log", "HEAD..origin/main", "--oneline"])
 
     return [commit.strip() for commit in new_commits.split("\n") if commit.strip() != ""]
 
@@ -51,14 +49,17 @@ def update_bnd(print_new_commits: bool = False):
 
     if len(new_commits) > 0:
         print("New commits found, pulling changes...")
+        print(3 * "\n")
 
         # pull changes from origin/main
-        _run_git_command(package_path, ["pull", "origin", "poetry_install_on_update"])
+        _run_git_command(package_path, ["pull", "origin", "main"])
 
         # install the updated package
         subprocess.run(["poetry", "install"], cwd=package_path)
 
+        print(3 * "\n")
         print("Package updated successfully.")
+        print("\n")
 
         if print_new_commits:
             print("New commits:")

--- a/src/beneuro_data/update_bnd.py
+++ b/src/beneuro_data/update_bnd.py
@@ -49,7 +49,10 @@ def update_bnd(print_new_commits: bool = False):
 
     if len(new_commits) > 0:
         print("New commits found, pulling changes...")
+        # pull changes from origin/main
         _run_git_command(package_path, ["pull", "origin", "main"])
+        # install the updated package
+        subprocess.run(["poetry", "install"], cwd=package_path)
         print("Package updated successfully.")
 
         if print_new_commits:

--- a/src/beneuro_data/update_bnd.py
+++ b/src/beneuro_data/update_bnd.py
@@ -51,10 +51,13 @@ def update_bnd(print_new_commits: bool = False):
 
     if len(new_commits) > 0:
         print("New commits found, pulling changes...")
+
         # pull changes from origin/main
         _run_git_command(package_path, ["pull", "origin", "poetry_install_on_update"])
+
         # install the updated package
         subprocess.run(["poetry", "install"], cwd=package_path)
+
         print("Package updated successfully.")
 
         if print_new_commits:

--- a/src/beneuro_data/update_bnd.py
+++ b/src/beneuro_data/update_bnd.py
@@ -20,7 +20,9 @@ def _get_new_commits(repo_path: str) -> list[str]:
     _run_git_command(repo_path, ["fetch"])
 
     # Check if origin/main has new commits compared to the local branch
-    new_commits = _run_git_command(repo_path, ["log", "HEAD..origin/main", "--oneline"])
+    new_commits = _run_git_command(
+        repo_path, ["log", "HEAD..origin/poetry_install_on_update", "--oneline"]
+    )
 
     return [commit.strip() for commit in new_commits.split("\n") if commit.strip() != ""]
 
@@ -50,7 +52,7 @@ def update_bnd(print_new_commits: bool = False):
     if len(new_commits) > 0:
         print("New commits found, pulling changes...")
         # pull changes from origin/main
-        _run_git_command(package_path, ["pull", "origin", "main"])
+        _run_git_command(package_path, ["pull", "origin", "poetry_install_on_update"])
         # install the updated package
         subprocess.run(["poetry", "install"], cwd=package_path)
         print("Package updated successfully.")

--- a/src/beneuro_data/update_bnd.py
+++ b/src/beneuro_data/update_bnd.py
@@ -54,6 +54,12 @@ def update_bnd(print_new_commits: bool = False):
         # pull changes from origin/main
         _run_git_command(package_path, ["pull", "origin", "main"])
 
+        print(
+            "NOTE: If the install hangs, running the following then retrying might help:",
+            end="\t",
+        )
+        print("export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring")
+
         # install the updated package
         subprocess.run(["poetry", "install"], cwd=package_path)
 


### PR DESCRIPTION
Self-update only pulled the changes, but if there was a change in dependencies, that wasn't reflected in the local installation.
Running `poetry install` should help with that.

Also added a note that might help if Poetry hangs during installation.