### PR TITLE
Simplify CLI

### DIFF
--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -799,8 +799,10 @@ def up(
     """
     Upload (raw) experimental data to the remote server.
 
-    Example usage to upload everything:
+    Example usage to upload everything of a given session:
         `bnd up M017_2024_03_12_18_45 -ev`
+    Example to upload the videos and ephys of the last session of a subject:
+        `bnd up M017 -evB`
     """
     animal = session_name[:4]
 
@@ -821,20 +823,32 @@ def up(
 
     config = _load_config()
 
-    up_done = upload_raw_session(
-        config.LOCAL_PATH / processing_level / animal / session_name,
-        animal,
-        config.LOCAL_PATH,
-        config.REMOTE_PATH,
-        include_behavior,
-        include_ephys,
-        include_videos,
-        include_extra_files,
-        config.WHITELISTED_FILES_IN_ROOT,
-        config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
-        rename_videos_first,
-        rename_extra_files_first,
-    )
+    if len(session_name) > 4:  # session name is given
+        up_done = upload_raw_session(
+            config.LOCAL_PATH / processing_level / animal / session_name,
+            animal,
+            config.LOCAL_PATH,
+            config.REMOTE_PATH,
+            include_behavior,
+            include_ephys,
+            include_videos,
+            include_extra_files,
+            config.WHITELISTED_FILES_IN_ROOT,
+            config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
+            rename_videos_first,
+            rename_extra_files_first,
+        )
+    else:  # only animal name is given
+        up_done = upload_last(
+            animal,
+            include_behavior,
+            include_ephys,
+            include_videos,
+            include_extra_files,
+            rename_videos_first,
+            rename_extra_files_first,
+            processing_level,
+        )
     if up_done is True:
         print(f"Session {session_name} uploaded successfully.")
 

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -348,6 +348,7 @@ def dl(
         whitelisted_files_in_root = config.WHITELISTED_FILES_IN_ROOT,
         allowed_extensions_not_in_root = config.EXTENSIONS_TO_RENAME_AND_UPLOAD
         )
+    print(f"Session {session_name} downloaded successfully.")
 
     return True
 
@@ -795,7 +796,6 @@ def up(
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
 ):
-
     """
     Upload (raw) experimental data to the remote server.
 
@@ -821,7 +821,7 @@ def up(
 
     config = _load_config()
 
-    upload_raw_session(
+    up_done = upload_raw_session(
         config.LOCAL_PATH / processing_level / animal / session_name,
         animal,
         config.LOCAL_PATH,
@@ -835,6 +835,8 @@ def up(
         rename_videos_first,
         rename_extra_files_first,
     )
+    if up_done is True:
+        print(f"Session {session_name} uploaded successfully.")
 
     return True
 

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -290,6 +290,83 @@ def download_session(
 
 
 @app.command()
+def download(
+    remote_session_path: Annotated[
+        Path, typer.Argument(help="Path to session directory. Can be relative or absolute.")
+    ],
+    subject_name: Annotated[
+        str,
+        typer.Argument(
+            help="Name of the subject the session belongs to. (Used for confirmation.)"
+        ),
+    ],
+    include_behavior: Annotated[
+        bool,
+        typer.Option(
+            "--include-behavior/--ignore-behavior",
+            help="Download behavioral data or not.",
+            prompt=True,
+        ),
+    ],
+    include_ephys: Annotated[
+        bool,
+        typer.Option(
+            "--include-ephys/--ignore-ephys",
+            help="Download ephys data or not.",
+            prompt=True,
+        ),
+    ],
+    include_videos: Annotated[
+        bool,
+        typer.Option(
+            "--include-videos/--ignore-videos",
+            help="Download video data or not.",
+            prompt=True,
+        ),
+    ],
+    # extra files are always included
+    # TODO do we want this to stay this way?
+    # include_extra_files: Annotated[
+    #    bool,
+    #    typer.Option(
+    #        "--include-extra-files/--ignore-extra-files",
+    #        help="Download extra files that are created by the experimenter or other software.",
+    #    ),
+    # ] = True,
+    processing_level: Annotated[
+        str, typer.Argument(help="Processing level of the session. raw or processed.")
+    ] = "raw",
+):
+    """
+    Download (raw) experimental data in a given session from the remote server.
+
+    Example usage after navigating to session folder on RDS:
+        `bnd download-session . M017`
+    """
+    if processing_level != "raw":
+        raise NotImplementedError("Sorry, only raw data is supported for now.")
+
+    if all([not include_behavior, not include_ephys, not include_videos]):
+        raise ValueError("At least one data type must be included.")
+
+    config = _load_config()
+
+    download_raw_session(
+        remote_session_path.absolute(),
+        subject_name,
+        config.LOCAL_PATH,
+        config.REMOTE_PATH,
+        include_behavior,
+        include_ephys,
+        include_videos,
+        config.WHITELISTED_FILES_IN_ROOT,
+        config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
+    )
+
+    return True
+
+
+@app.command()
 def kilosort_session(
     local_session_path: Annotated[
         Path, typer.Argument(help="Path to session directory. Can be relative or absolute")

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -348,7 +348,7 @@ def dl(
         whitelisted_files_in_root = config.WHITELISTED_FILES_IN_ROOT,
         allowed_extensions_not_in_root = config.EXTENSIONS_TO_RENAME_AND_UPLOAD
         )
-    print(f"Session {session_name} downloaded successfully.")
+    print(f"Session {session_name} downloaded.")
 
     return True
 
@@ -744,8 +744,8 @@ def upload_session(
 
 @app.command()
 def up(
-    session_name: Annotated[
-        str, typer.Argument(help="Name of session: M123_2000_02_03_14_15")
+    session_or_animal_name: Annotated[
+        str, typer.Argument(help="Animal or session name: M123_2000_02_03_14_15")
     ],
     include_behavior: Annotated[
         bool,
@@ -804,7 +804,7 @@ def up(
     Example to upload the videos and ephys of the last session of a subject:
         `bnd up M017 -evB`
     """
-    animal = session_name[:4]
+    animal = session_or_animal_name[:4]
 
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
@@ -823,9 +823,9 @@ def up(
 
     config = _load_config()
 
-    if len(session_name) > 4:  # session name is given
+    if len(session_or_animal_name) > 4:  # session name is given
         up_done = upload_raw_session(
-            config.LOCAL_PATH / processing_level / animal / session_name,
+            config.LOCAL_PATH / processing_level / animal / session_or_animal_name,
             animal,
             config.LOCAL_PATH,
             config.REMOTE_PATH,
@@ -849,8 +849,8 @@ def up(
             rename_extra_files_first,
             processing_level,
         )
-    if up_done is True:
-        print(f"Session {session_name} uploaded successfully.")
+    if up_done:
+        print(f"Session {session_or_animal_name} uploaded.")
 
     return True
 

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -752,7 +752,7 @@ def up(
         typer.Option(
             "--include-behavior/--ignore-behavior",
             "-b/-B",
-            help="Download behavioral data (-b) or not (-B)."
+            help="upload behavioral data (-b) or not (-B)."
         ),
     ] = True,
     include_ephys: Annotated[
@@ -760,7 +760,7 @@ def up(
         typer.Option(
             "--include-ephys/--ignore-ephys",
             "-e/-E",
-            help="Download ephys data (-e) or not (-E)."
+            help="upload ephys data (-e) or not (-E)."
         ),
     ] = False,
     include_videos: Annotated[
@@ -768,7 +768,7 @@ def up(
         typer.Option(
             "--include-videos/--ignore-videos",
             "-v/-V",
-            help="Download video data (-v) or not (-V)."
+            help="upload video data (-v) or not (-V)."
         ),
     ] = False,
     include_extra_files: Annotated[

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -745,14 +745,14 @@ def upload_session(
 @app.command()
 def up(
     session_or_animal_name: Annotated[
-        str, typer.Argument(help="Animal or session name: M123_2000_02_03_14_15")
+        str, typer.Argument(help="Animal or session name: M123 or M123_2000_02_03_14_15")
     ],
     include_behavior: Annotated[
         bool,
         typer.Option(
             "--include-behavior/--ignore-behavior",
             "-b/-B",
-            help="upload behavioral data (-b) or not (-B)."
+            help="Upload behavioral data (-b) or not (-B)."
         ),
     ] = True,
     include_ephys: Annotated[
@@ -760,7 +760,7 @@ def up(
         typer.Option(
             "--include-ephys/--ignore-ephys",
             "-e/-E",
-            help="upload ephys data (-e) or not (-E)."
+            help="Upload ephys data (-e) or not (-E)."
         ),
     ] = False,
     include_videos: Annotated[
@@ -768,7 +768,7 @@ def up(
         typer.Option(
             "--include-videos/--ignore-videos",
             "-v/-V",
-            help="upload video data (-v) or not (-V)."
+            help="Upload video data (-v) or not (-V)."
         ),
     ] = False,
     include_extra_files: Annotated[
@@ -838,6 +838,7 @@ def up(
             rename_videos_first,
             rename_extra_files_first,
         )
+        message = f"Session {session_or_animal_name} uploaded."
     else:  # only animal name is given
         up_done = upload_last(
             animal,
@@ -849,8 +850,9 @@ def up(
             rename_extra_files_first,
             processing_level,
         )
+        message = f"Last session of {animal} uploaded."
     if up_done:
-        print(f"Session {session_or_animal_name} uploaded.")
+        print(message)
 
     return True
 


### PR DESCRIPTION
Adding 2 CLI functions to easily upload (`up`) and download (`dl`) different data streams. Inferring session names and animal names etc with minimal input from the user. Also, giving a simple feedback when copying succeeded.