### PR TITLE
remove unnecessary error

### DIFF
--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -784,7 +784,7 @@ def up(
             "--rename/--no-rename",
             help="Rename videos before validating and uploading.",
         ),
-    ] = True,
+    ] = None,
     rename_extra_files_first: Annotated[
         bool,
         typer.Option(

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -816,6 +816,11 @@ def up(
     if rename_videos_first is None:
         rename_videos_first = include_videos
 
+    if rename_videos_first and not include_videos:
+        raise ValueError(
+            "Do not rename videos if you're not uploading them. (Meaning --ignore-videos and --rename-videos are not allowed together.)"
+        )
+
     config = _load_config()
 
     if len(session_or_animal_name) > 4:  # session name is given

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -816,11 +816,6 @@ def up(
     if rename_videos_first is None:
         rename_videos_first = include_videos
 
-    if rename_videos_first and not include_videos:
-        raise ValueError(
-            "Do not rename videos if you're not uploading them. (Meaning --ignore-videos and --rename-videos are not allowed together.)"
-        )
-
     config = _load_config()
 
     if len(session_or_animal_name) > 4:  # session name is given


### PR DESCRIPTION
By default, always throw an error given the default arguments.
It's not a problem to rename any file locally.