### PR TITLE
Fix time units in NWB conversion

### DIFF
--- a/src/beneuro_data/conversion/anipose_interface.py
+++ b/src/beneuro_data/conversion/anipose_interface.py
@@ -5,14 +5,16 @@ import h5py
 import numpy as np
 import spikeinterface.extractors as se
 from ndx_pose import PoseEstimation, PoseEstimationSeries
-from neuroconv.basetemporalalignmentinterface import \
+from neuroconv.basetemporalalignmentinterface import (
     BaseTemporalAlignmentInterface
+)
 from neuroconv.tools.signal_processing import get_rising_frames_from_ttl
 from neuroconv.utils import DeepDict, FilePathType
 from pynwb import NWBFile
 
-from beneuro_data.data_validation import \
+from beneuro_data.data_validation import (
     _find_spikeglx_recording_folders_in_session
+)
 from beneuro_data.spike_sorting import get_ap_stream_names
 
 DEFAULT_FPS = 100
@@ -95,6 +97,7 @@ class AniposeInterface(BaseTemporalAlignmentInterface):
                 unit="a.u.",  # TODO
                 reference_frame="(0, 0, 0) is what?",  # TODO
                 timestamps=timestamps,
+                timestamps_unit="s",
                 starting_time=starting_time,
                 rate=rate,
                 confidence=np.full(self.n_frames, np.nan),

--- a/src/beneuro_data/conversion/pycontrol_interface.py
+++ b/src/beneuro_data/conversion/pycontrol_interface.py
@@ -8,8 +8,9 @@ from pathlib import Path
 
 import dateutil.tz
 import numpy as np
-from neuroconv.basetemporalalignmentinterface import \
+from neuroconv.basetemporalalignmentinterface import (
     BaseTemporalAlignmentInterface
+)
 from neuroconv.utils import DeepDict, FilePathType
 from pynwb import NWBFile
 from pynwb.behavior import BehavioralEvents, Position, SpatialSeries
@@ -115,7 +116,7 @@ class PyControlInterface(BaseTemporalAlignmentInterface):
             name="Ball position",
             description="(x,y) position as measured by PyControl",
             data=self._get_pos_data(),
-            timestamps=self._get_pos_timestamps().astype(float),
+            timestamps=self._get_pos_timestamps().astype(float) / 1000,
             reference_frame="(0,0) is what?",  # TODO
         )
 
@@ -133,7 +134,7 @@ class PyControlInterface(BaseTemporalAlignmentInterface):
                     for it in self.session.print_data
                     if it.name == print_item
                 ],
-                unit="",
+                unit="ms",
             )
 
         self._add_to_behavior_module(print_events, nwbfile)
@@ -145,7 +146,7 @@ class PyControlInterface(BaseTemporalAlignmentInterface):
             name="behavioral events",
             data=[e.name for e in self.session.events],
             timestamps=[float(e.time) for e in self.session.events],
-            unit="",
+            unit="ms",
         )
 
         self._add_to_behavior_module(behavioral_events, nwbfile)
@@ -179,14 +180,14 @@ class PyControlInterface(BaseTemporalAlignmentInterface):
 
         for state in self.session.states:
             duration = (
-                state.duration
+                state.duration / 1000
                 if state.duration is not None
                 else session_length - state.time
             )
 
             behavioral_states.add_row(
-                start_time=float(state.time),
-                stop_time=float(state.time + duration),
+                start_time=float(state.time) / 1000,
+                stop_time=float(state.time + duration) / 1000,
                 state_name=state.name,
             )
 


### PR DESCRIPTION
Data from different modalities have different units of time. For proper synchronization we have to know what these are and get them to a common time axis.