### PR TITLE
Configure black, isort, ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ bnd = "beneuro_data.cli:app"
 [tool.black]
 line-length = 92
 
+[tool.ruff]
+line-length = 92
+
+[tool.isort]
+profile = "black"
+
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:.*No correctly named video folder found*:UserWarning",

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -10,9 +10,11 @@ from beneuro_data.config import _get_env_path, _get_package_path, _load_config
 from beneuro_data.data_transfer import download_raw_session, upload_raw_session
 from beneuro_data.data_validation import validate_raw_session
 from beneuro_data.extra_file_handling import rename_extra_files_in_session
-from beneuro_data.query_sessions import (get_last_session_path,
-                                         list_all_sessions_on_day,
-                                         list_subject_sessions_on_day)
+from beneuro_data.query_sessions import (
+    get_last_session_path,
+    list_all_sessions_on_day,
+    list_subject_sessions_on_day,
+)
 from beneuro_data.update_bnd import check_for_updates, update_bnd
 from beneuro_data.video_renaming import rename_raw_videos_of_session
 
@@ -299,7 +301,7 @@ def dl(
         typer.Option(
             "--include-behavior/--ignore-behavior",
             "-b/-B",
-            help="Download behavioral data (-b) or not (-B)."
+            help="Download behavioral data (-b) or not (-B).",
         ),
     ] = True,
     include_ephys: Annotated[
@@ -307,7 +309,7 @@ def dl(
         typer.Option(
             "--include-ephys/--ignore-ephys",
             "-e/-E",
-            help="Download ephys data (-e) or not (-E)."
+            help="Download ephys data (-e) or not (-E).",
         ),
     ] = False,
     include_videos: Annotated[
@@ -315,7 +317,7 @@ def dl(
         typer.Option(
             "--include-videos/--ignore-videos",
             "-v/-V",
-            help="Download video data (-v) or not (-V)."
+            help="Download video data (-v) or not (-V).",
         ),
     ] = False,
     processing_level: Annotated[
@@ -338,16 +340,16 @@ def dl(
     config = _load_config()
 
     download_raw_session(
-        remote_session_path = config.REMOTE_PATH / processing_level / animal / session_name,
-        subject_name = animal,
-        local_base_path = config.LOCAL_PATH,
-        remote_base_path = config.REMOTE_PATH,
-        include_behavior = include_behavior,
-        include_ephys = include_ephys,
-        include_videos = include_videos,
-        whitelisted_files_in_root = config.WHITELISTED_FILES_IN_ROOT,
-        allowed_extensions_not_in_root = config.EXTENSIONS_TO_RENAME_AND_UPLOAD
-        )
+        remote_session_path=config.REMOTE_PATH / processing_level / animal / session_name,
+        subject_name=animal,
+        local_base_path=config.LOCAL_PATH,
+        remote_base_path=config.REMOTE_PATH,
+        include_behavior=include_behavior,
+        include_ephys=include_ephys,
+        include_videos=include_videos,
+        whitelisted_files_in_root=config.WHITELISTED_FILES_IN_ROOT,
+        allowed_extensions_not_in_root=config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
+    )
     print(f"Session {session_name} downloaded.")
 
     return True
@@ -404,8 +406,7 @@ def kilosort_session(
         `bnd kilosort-session . M020 --no-verbose`
     """
     # this will throw an error if the dependencies are not available
-    from beneuro_data.spike_sorting import \
-        run_kilosort_on_session_and_save_in_processed
+    from beneuro_data.spike_sorting import run_kilosort_on_session_and_save_in_processed
 
     config = _load_config()
 
@@ -752,7 +753,7 @@ def up(
         typer.Option(
             "--include-behavior/--ignore-behavior",
             "-b/-B",
-            help="Upload behavioral data (-b) or not (-B)."
+            help="Upload behavioral data (-b) or not (-B).",
         ),
     ] = True,
     include_ephys: Annotated[
@@ -760,7 +761,7 @@ def up(
         typer.Option(
             "--include-ephys/--ignore-ephys",
             "-e/-E",
-            help="Upload ephys data (-e) or not (-E)."
+            help="Upload ephys data (-e) or not (-E).",
         ),
     ] = False,
     include_videos: Annotated[
@@ -768,7 +769,7 @@ def up(
         typer.Option(
             "--include-videos/--ignore-videos",
             "-v/-V",
-            help="Upload video data (-v) or not (-V)."
+            help="Upload video data (-v) or not (-V).",
         ),
     ] = False,
     include_extra_files: Annotated[

--- a/src/beneuro_data/conversion/animal_profile_interface.py
+++ b/src/beneuro_data/conversion/animal_profile_interface.py
@@ -8,8 +8,7 @@ from neuroconv.utils import DeepDict, FilePathType
 from pynwb import NWBFile
 from pynwb.file import Subject
 
-from beneuro_data.data_validation import (EXPECTED_DATE_FORMAT,
-                                          validate_session_path)
+from beneuro_data.data_validation import EXPECTED_DATE_FORMAT, validate_session_path
 
 
 class AnimalProfileInterface(BaseDataInterface):

--- a/src/beneuro_data/conversion/beneuro_converter.py
+++ b/src/beneuro_data/conversion/beneuro_converter.py
@@ -3,15 +3,14 @@ from pathlib import Path
 import numpy as np
 import spikeinterface.extractors as se
 from neuroconv import NWBConverter
-from neuroconv.datainterfaces import \
-    SpikeGLXRecordingInterface  # PhySortingInterface
+from neuroconv.datainterfaces import SpikeGLXRecordingInterface  # PhySortingInterface
 from neuroconv.tools.signal_processing import get_rising_frames_from_ttl
 
-from beneuro_data.conversion.animal_profile_interface import \
-    AnimalProfileInterface
+from beneuro_data.conversion.animal_profile_interface import AnimalProfileInterface
 from beneuro_data.conversion.anipose_interface import AniposeInterface
-from beneuro_data.conversion.multiprobe_kilosort_interface import \
-    MultiProbeKiloSortInterface
+from beneuro_data.conversion.multiprobe_kilosort_interface import (
+    MultiProbeKiloSortInterface,
+)
 from beneuro_data.conversion.pycontrol_interface import PyControlInterface
 
 

--- a/src/beneuro_data/conversion/convert_to_nwb.py
+++ b/src/beneuro_data/conversion/convert_to_nwb.py
@@ -2,17 +2,18 @@ import warnings
 from pathlib import Path
 from typing import Optional
 
-from beneuro_data.conversion.animal_profile_interface import \
-    AnimalProfileInterface
+from beneuro_data.conversion.animal_profile_interface import AnimalProfileInterface
 from beneuro_data.conversion.anipose_interface import AniposeInterface
 from beneuro_data.conversion.beneuro_converter import BeNeuroConverter
 from beneuro_data.conversion.gpu_memory import get_free_gpu_memory
-from beneuro_data.conversion.multiprobe_kilosort_interface import \
-    MultiProbeKiloSortInterface
+from beneuro_data.conversion.multiprobe_kilosort_interface import (
+    MultiProbeKiloSortInterface,
+)
 from beneuro_data.data_validation import (
-    _find_spikeglx_recording_folders_in_session, validate_raw_session)
-from beneuro_data.spike_sorting import \
-    run_kilosort_on_session_and_save_in_processed
+    _find_spikeglx_recording_folders_in_session,
+    validate_raw_session,
+)
+from beneuro_data.spike_sorting import run_kilosort_on_session_and_save_in_processed
 
 
 def _try_adding_kilosort_to_source_data(
@@ -68,8 +69,9 @@ def _try_adding_anipose_to_source_data(
         return
 
     if len(csv_paths) > 1:
-        raise FileExistsError(f"More than one pose estimation HDF file "
-                              f"found: {csv_paths}")
+        raise FileExistsError(
+            f"More than one pose estimation HDF file " f"found: {csv_paths}"
+        )
 
     csv_path = csv_paths[0]
     try:

--- a/src/beneuro_data/conversion/pycontrol_data_import.py
+++ b/src/beneuro_data/conversion/pycontrol_data_import.py
@@ -2,10 +2,11 @@
 # Copied from @JoannaChang's behavior_analysis repo
 
 import os
-import numpy as np
 import re
-from datetime import datetime
 from collections import namedtuple
+from datetime import datetime
+
+import numpy as np
 
 Event = namedtuple("Event", ["time", "name"])
 State = namedtuple("State", ["time", "name", "duration"])

--- a/src/beneuro_data/conversion/pycontrol_interface.py
+++ b/src/beneuro_data/conversion/pycontrol_interface.py
@@ -8,8 +8,7 @@ from pathlib import Path
 
 import dateutil.tz
 import numpy as np
-from neuroconv.basetemporalalignmentinterface import \
-    BaseTemporalAlignmentInterface
+from neuroconv.basetemporalalignmentinterface import BaseTemporalAlignmentInterface
 from neuroconv.utils import DeepDict, FilePathType
 from pynwb import NWBFile
 from pynwb.behavior import BehavioralEvents, Position, SpatialSeries

--- a/src/beneuro_data/data_transfer.py
+++ b/src/beneuro_data/data_transfer.py
@@ -1,6 +1,12 @@
-from pathlib import Path
 import warnings
+from pathlib import Path
 
+from beneuro_data.data_transfer_helpers import (
+    _check_list_of_files_before_copy,
+    _copy_list_of_files,
+    _source_to_dest,
+    _validate_session_is_raw_and_in_root,
+)
 from beneuro_data.data_validation import (
     validate_raw_behavioral_data_of_session,
     validate_raw_ephys_data_of_session,
@@ -11,12 +17,6 @@ from beneuro_data.extra_file_handling import (
     _find_extra_files_with_extensions,
     _find_whitelisted_files_in_root,
     rename_extra_files_in_session,
-)
-from beneuro_data.data_transfer_helpers import (
-    _source_to_dest,
-    _copy_list_of_files,
-    _check_list_of_files_before_copy,
-    _validate_session_is_raw_and_in_root,
 )
 from beneuro_data.validate_argument import validate_argument
 from beneuro_data.video_renaming import rename_raw_videos_of_session

--- a/src/beneuro_data/data_transfer_helpers.py
+++ b/src/beneuro_data/data_transfer_helpers.py
@@ -1,7 +1,7 @@
-from typing import Union
-from pathlib import Path
-import shutil
 import filecmp
+import shutil
+from pathlib import Path
+from typing import Union
 
 
 def _source_to_dest(

--- a/src/beneuro_data/query_sessions.py
+++ b/src/beneuro_data/query_sessions.py
@@ -1,8 +1,8 @@
-from pathlib import Path
 import datetime
+from pathlib import Path
 
-from .data_validation import validate_session_path, EXPECTED_DATE_FORMAT
 from .config import _load_config
+from .data_validation import EXPECTED_DATE_FORMAT, validate_session_path
 
 
 def list_subject_sessions(

--- a/src/beneuro_data/spike_sorting.py
+++ b/src/beneuro_data/spike_sorting.py
@@ -8,7 +8,7 @@ from spikeinterface.sorters.utils.misc import (
     has_docker,
     has_docker_nvidia_installed,
     has_docker_python,
-    has_nvidia
+    has_nvidia,
 )
 
 try:
@@ -22,7 +22,7 @@ except ImportError as e:
 
 from beneuro_data.data_validation import (
     _find_spikeglx_recording_folders_in_session,
-    validate_raw_ephys_data_of_session
+    validate_raw_ephys_data_of_session,
 )
 
 

--- a/src/beneuro_data/video_renaming.py
+++ b/src/beneuro_data/video_renaming.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
+from rich import print as rprint
+
 from beneuro_data.data_validation import (
     validate_raw_videos_of_session,
     validate_session_path,
 )
-
-from rich import print as rprint
 
 
 def rename_raw_videos_of_session(

--- a/tests/test_data_transfer.py
+++ b/tests/test_data_transfer.py
@@ -3,15 +3,14 @@ from dataclasses import dataclass
 from typing import Optional, Type
 
 import pytest
+from test_data_validation import (
+    EXTENSIONS_TO_RENAME_AND_UPLOAD,
+    WHITELISTED_FILES_IN_ROOT,
+    _prepare_directory_structure,
+)
 
 from beneuro_data.data_transfer import sync_subject_dir, upload_raw_session
 from beneuro_data.data_validation import WrongNumberOfFilesError
-
-from test_data_validation import (
-    _prepare_directory_structure,
-    WHITELISTED_FILES_IN_ROOT,
-    EXTENSIONS_TO_RENAME_AND_UPLOAD,
-)
 
 TEST_DIR_PATH = os.path.dirname(__file__)
 UPLOAD_RAW_SESSION_YAML_FOLDER = os.path.join(

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -1,17 +1,14 @@
-import pytest
-
 import os
-import shutil
 import pathlib
+import shutil
 from dataclasses import dataclass
-from typing import Type, Optional
+from typing import Optional, Type
 
+import pytest
+from generate_directory_structure_test_cases import create_directory_structure_from_dict
 from ruamel.yaml import YAML
 
-from beneuro_data.data_validation import validate_raw_session, WrongNumberOfFilesError
-
-from generate_directory_structure_test_cases import create_directory_structure_from_dict
-
+from beneuro_data.data_validation import WrongNumberOfFilesError, validate_raw_session
 
 TEST_DIR_PATH = os.path.dirname(__file__)
 DIRECTORY_STRUCTURE_YAML_FOLDER = os.path.join(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,15 +3,14 @@ from dataclasses import dataclass
 from typing import Optional, Type
 
 import pytest
+from test_data_validation import (
+    EXTENSIONS_TO_RENAME_AND_UPLOAD,
+    WHITELISTED_FILES_IN_ROOT,
+    _prepare_directory_structure,
+)
 
 from beneuro_data.data_transfer import download_raw_session
 from beneuro_data.data_validation import WrongNumberOfFilesError
-
-from test_data_validation import (
-    _prepare_directory_structure,
-    WHITELISTED_FILES_IN_ROOT,
-    EXTENSIONS_TO_RENAME_AND_UPLOAD,
-)
 
 TEST_DIR_PATH = os.path.dirname(__file__)
 DOWNLOAD_RAW_SESSION_TEST_FOLDER = os.path.join(
@@ -83,7 +82,7 @@ session_download_test_cases = [
     # TODO not wanting to download bad behavior should not warn
     # the test itself is incorrect for this case
     # use data validation functions on both sides to compare list of files
-    #RawSessionDownloadTestCase(
+    # RawSessionDownloadTestCase(
     #    "M011_wrong_behavior.yaml",
     #    "M011_2023_04_04_16_00",
     #    None,
@@ -91,7 +90,7 @@ session_download_test_cases = [
     #    False,
     #    True,
     #    True,
-    #),
+    # ),
 ]
 
 

--- a/tests/test_extra_file_renaming.py
+++ b/tests/test_extra_file_renaming.py
@@ -1,19 +1,18 @@
-import pytest
-
+import os
 from dataclasses import dataclass
 from pathlib import Path
-import os
 from typing import Optional, Type
 
-from beneuro_data.extra_file_handling import (
-    _rename_whitelisted_files_in_root,
-    _rename_extra_files_with_extension,
-)
-
+import pytest
 from test_data_validation import (
     TEST_DIR_PATH,
     _prepare_directory_structure,
     validate_raw_session,
+)
+
+from beneuro_data.extra_file_handling import (
+    _rename_extra_files_with_extension,
+    _rename_whitelisted_files_in_root,
 )
 
 EXTRA_FILE_RENAMING_YAML_FOLDER = Path(TEST_DIR_PATH) / "extra_file_renaming_test_yamls"

--- a/tests/test_last_session.py
+++ b/tests/test_last_session.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
-
-import pytest
 from pathlib import Path
 
+import pytest
 from test_data_validation import _prepare_directory_structure
 
 from beneuro_data.query_sessions import get_last_session_path

--- a/tests/test_listing_sessions_on_day.py
+++ b/tests/test_listing_sessions_on_day.py
@@ -1,16 +1,14 @@
-from dataclasses import dataclass
-
-import pytest
 import datetime
+from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
 from test_data_validation import _prepare_directory_structure
 
 from beneuro_data.query_sessions import (
-    list_subject_sessions_on_day,
     list_all_sessions_on_day,
+    list_subject_sessions_on_day,
 )
-
 
 TEST_DIR_PATH = Path(__file__).parent
 DAYS_SESSIONS_TEST_YAML_FOLDER = TEST_DIR_PATH / "list_days_sessions_test_yamls"

--- a/tests/test_video_renaming.py
+++ b/tests/test_video_renaming.py
@@ -1,15 +1,14 @@
-import pytest
-
-from pathlib import Path
 import os
+from pathlib import Path
 
-from beneuro_data.video_renaming import rename_raw_videos_of_session
-from beneuro_data.data_validation import validate_raw_videos_of_session
-
+import pytest
 from test_data_validation import (
     DIRECTORY_STRUCTURE_YAML_FOLDER,
     _prepare_directory_structure,
 )
+
+from beneuro_data.data_validation import validate_raw_videos_of_session
+from beneuro_data.video_renaming import rename_raw_videos_of_session
 
 test_cases = [
     ("M011_wrong_video_filenames.yaml", "M011_2023_04_04_16_00"),


### PR DESCRIPTION
Added some configuration to the pyproject.toml to have consistent formatting, and reformatted everything.
The following are now hopefully equivalent:
```
black .
isort .
```
```
ruff check --select I --fix
ruff format
```