### PR TITLE
Closes #81 : Added full session name to pyaldata column `session`

### DIFF
--- a/src/beneuro_data/conversion/convert_nwb_to_pyaldata.py
+++ b/src/beneuro_data/conversion/convert_nwb_to_pyaldata.py
@@ -660,7 +660,7 @@ class ParsedNWBFile:
     def add_mouse_and_session(self):
         self.pyaldata_df["animal"] = [self.subject_id] * len(self.pyaldata_df)
         self.pyaldata_df["session"] = (
-            [self.nwbfile_path.name[5:-4]]
+            [self.nwbfile_path.name[:-4]]
             * len(self.pyaldata_df)
         )
         return

--- a/tests/conversion/test_pyaldata_conversion.py
+++ b/tests/conversion/test_pyaldata_conversion.py
@@ -11,7 +11,7 @@ from beneuro_data.conversion.convert_nwb_to_pyaldata import convert_nwb_to_pyald
 @pytest.mark.needs_experimental_data
 @pytest.mark.processing
 @pytest.mark.parametrize("session_name", ["M030_2024_04_12_09_40"])
-def test_nwb_to_pyaldata(session_name):
+def test_pyaldata_converter(session_name):
     config = _load_config()
     local_session_path = config.get_local_session_path(session_name, "processed")
 
@@ -24,8 +24,15 @@ def test_nwb_to_pyaldata(session_name):
         mat_file.unlink()
 
     nwbfile_path = nwbfiles[0].absolute()
-
     convert_nwb_to_pyaldata(nwbfile_path=nwbfile_path, verbose=False)
+
+
+@pytest.mark.needs_experimental_data
+@pytest.mark.processing
+@pytest.mark.parametrize("session_name", ["M030_2024_04_12_09_40"])
+def test_pyaldata_loading_and_format(session_name):
+    config = _load_config()
+    local_session_path = config.get_local_session_path(session_name, "processed")
     mat = scipy.io.loadmat(
         local_session_path / f"{session_name}_pyaldata.mat", simplify_cells=True
     )
@@ -78,7 +85,7 @@ def test_nwb_to_pyaldata(session_name):
 
     # Assert that all expected columns are present
     # TODO: Add some more thorough checking on the data structure.
-
+    assert all(df['session'] == session_name)
     assert set(expected_columns).issubset(
         df.columns
     ), f"Missing columns: {set(expected_columns) - set(df.columns)}"


### PR DESCRIPTION
This PR addresses the issue where the `session` column in the pyaldata frame doesn't have the full session name

- Added full session name
- Included session name check in pyaldata tests
- Separated loading and format checking in pyaldata tests

Closes #81