### PR TITLE
Feature/include kilosort output

### DIFF
--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -216,7 +216,7 @@ def download_last(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
-    include_kilosort_output: Annotated[
+    include_kilosort: Annotated[
         bool,
         typer.Option(
             "--include-kilosort-output/--ignore-kilosort-output",
@@ -254,10 +254,10 @@ def download_last(
         include_ephys = typer.confirm("Include ephys?")
     if include_videos is None:
         include_videos = typer.confirm("Include videos?")
-    if include_kilosort_output is None:
-        include_kilosort_output = typer.confirm("Include Kilosort output?")
+    if include_kilosort is None:
+        include_kilosort = typer.confirm("Include Kilosort output?")
 
-    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort]):
         raise ValueError("At least one data type must be included.")
 
     download_raw_session(
@@ -270,7 +270,7 @@ def download_last(
         include_videos,
         config.WHITELISTED_FILES_IN_ROOT,
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
-        include_kilosort_output=include_kilosort_output
+        include_kilosort=include_kilosort
     )
 
     return True
@@ -323,7 +323,7 @@ def download_session(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
-    include_kilosort_output: Annotated[
+    include_kilosort: Annotated[
         bool,
         typer.Option(
             "--include-kilosort-output/--ignore-kilosort-output",
@@ -340,7 +340,7 @@ def download_session(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort]):
         raise ValueError("At least one data type must be included.")
 
     config = _load_config()
@@ -355,7 +355,7 @@ def download_session(
         include_videos,
         config.WHITELISTED_FILES_IN_ROOT,
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
-        include_kilosort_output=include_kilosort_output
+        include_kilosort=include_kilosort
     )
 
     return True
@@ -393,7 +393,7 @@ def dl(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
-    include_kilosort_output: Annotated[
+    include_kilosort: Annotated[
         bool,
         typer.Option(
             "--include-kilosort-output/--ignore-kilosort-output",
@@ -412,7 +412,7 @@ def dl(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort]):
         raise ValueError("At least one data type must be included.")
 
     config = _load_config()
@@ -427,7 +427,7 @@ def dl(
         include_videos=include_videos,
         whitelisted_files_in_root=config.WHITELISTED_FILES_IN_ROOT,
         allowed_extensions_not_in_root=config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
-        include_kilosort_output=include_kilosort_output
+        include_kilosort=include_kilosort
     )
     print(f"Session {session_name} downloaded.")
 
@@ -546,7 +546,7 @@ def validate_session(
         bool,
         typer.Option("--check-videos/--ignore-videos", help="Check videos data or not."),
     ] = True,
-    check_kilosort_output: Annotated[
+    check_kilosort: Annotated[
         bool,
         typer.Option(
             "--check-kilosort-output/--ignore-kilosort-output",
@@ -564,7 +564,7 @@ def validate_session(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not check_behavior, not check_ephys, not check_videos, not check_kilosort_output]):
+    if all([not check_behavior, not check_ephys, not check_videos, not check_kilosort]):
         raise ValueError("At least one data type must be checked.")
 
     if not session_path.absolute().is_dir():
@@ -582,7 +582,7 @@ def validate_session(
         check_videos,
         config.WHITELISTED_FILES_IN_ROOT,
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
-        check_kilosort_output=check_kilosort_output
+        check_kilosort=check_kilosort
     )
 
 
@@ -615,7 +615,7 @@ def validate_last(
         bool,
         typer.Option("--check-videos/--ignore-videos", help="Check videos data or not."),
     ] = True,
-    check_kilosort_output: Annotated[
+    check_kilosort: Annotated[
         bool,
         typer.Option(
             "--check-kilosort-output/--ignore-kilosort-output",
@@ -632,7 +632,7 @@ def validate_last(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not check_behavior, not check_ephys, not check_videos, not check_kilosort_output]):
+    if all([not check_behavior, not check_ephys, not check_videos, not check_kilosort]):
         raise ValueError("At least one data type must be checked.")
 
     config = _load_config()
@@ -654,7 +654,7 @@ def validate_last(
         check_videos,
         config.WHITELISTED_FILES_IN_ROOT,
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
-        check_kilosort_output=check_kilosort_output
+        check_kilosort=check_kilosort
     )
 
 
@@ -793,7 +793,7 @@ def upload_session(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
-    include_kilosort_output: Annotated[
+    include_kilosort: Annotated[
         bool,
         typer.Option(
             "--include-kilosort-output/--ignore-kilosort-output",
@@ -810,7 +810,7 @@ def upload_session(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort]):
         raise ValueError("At least one data type must be included.")
 
     # if videos are included, rename them first if not specified otherwise
@@ -837,7 +837,7 @@ def upload_session(
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
         rename_videos_first,
         rename_extra_files_first,
-        include_kilosort_output=include_kilosort_output
+        include_kilosort=include_kilosort
     )
 
     return True
@@ -896,7 +896,7 @@ def up(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
-    include_kilosort_output: Annotated[
+    include_kilosort: Annotated[
         bool,
         typer.Option(
             "--include-kilosort-output/--ignore-kilosort-output",
@@ -918,7 +918,7 @@ def up(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort]):
         raise ValueError("At least one data type must be included.")
 
     # if videos are included, rename them first if not specified otherwise
@@ -946,7 +946,7 @@ def up(
             config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
             rename_videos_first,
             rename_extra_files_first,
-            include_kilosort_output=include_kilosort_output
+            include_kilosort=include_kilosort
         )
         message = f"Session {session_or_animal_name} uploaded."
     else:  # only animal name is given
@@ -959,7 +959,7 @@ def up(
             rename_videos_first,
             rename_extra_files_first,
             processing_level,
-            include_kilosort_output=include_kilosort_output
+            include_kilosort=include_kilosort
         )
         message = f"Last session of {animal} uploaded."
     if up_done:
@@ -1019,7 +1019,7 @@ def upload_last(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
-    include_kilosort_output: Annotated[
+    include_kilosort: Annotated[
         bool,
         typer.Option(
             "--include-kilosort-output/--ignore-kilosort-output",
@@ -1058,8 +1058,8 @@ def upload_last(
         include_ephys = typer.confirm("Include ephys?")
     if include_videos is None:
         include_videos = typer.confirm("Include videos?")
-    if include_kilosort_output is None:
-        include_kilosort_output = typer.confirm("Include Kilosort output?")
+    if include_kilosort is None:
+        include_kilosort = typer.confirm("Include Kilosort output?")
 
     if all([not include_behavior, not include_ephys, not include_videos]):
         raise ValueError("At least one data type must be included.")
@@ -1086,7 +1086,7 @@ def upload_last(
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
         rename_videos_first,
         rename_extra_files_first,
-        include_kilosort_output=include_kilosort_output
+        include_kilosort=include_kilosort
     )
 
     return True

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -216,6 +216,13 @@ def download_last(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
+    include_kilosort_output: Annotated[
+        bool,
+        typer.Option(
+            "--include-kilosort-output/--ignore-kilosort-output",
+            help="Upload Kilosort output or not.",
+        ),
+    ] = False
 ):
     """
     Download (raw) experimental data in the last session of a subject from the remote server.
@@ -247,8 +254,10 @@ def download_last(
         include_ephys = typer.confirm("Include ephys?")
     if include_videos is None:
         include_videos = typer.confirm("Include videos?")
+    if include_kilosort_output is None:
+        include_kilosort_output = typer.confirm("Include Kilosort output?")
 
-    if all([not include_behavior, not include_ephys, not include_videos]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
         raise ValueError("At least one data type must be included.")
 
     download_raw_session(
@@ -261,6 +270,7 @@ def download_last(
         include_videos,
         config.WHITELISTED_FILES_IN_ROOT,
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
+        include_kilosort_output=include_kilosort_output
     )
 
     return True
@@ -313,6 +323,13 @@ def download_session(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
+    include_kilosort_output: Annotated[
+        bool,
+        typer.Option(
+            "--include-kilosort-output/--ignore-kilosort-output",
+            help="Upload Kilosort output or not.",
+        ),
+    ] = False
 ):
     """
     Download (raw) experimental data in a given session from the remote server.
@@ -323,7 +340,7 @@ def download_session(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not include_behavior, not include_ephys, not include_videos]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
         raise ValueError("At least one data type must be included.")
 
     config = _load_config()
@@ -338,6 +355,7 @@ def download_session(
         include_videos,
         config.WHITELISTED_FILES_IN_ROOT,
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
+        include_kilosort_output=include_kilosort_output
     )
 
     return True
@@ -375,6 +393,14 @@ def dl(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
+    include_kilosort_output: Annotated[
+        bool,
+        typer.Option(
+            "--include-kilosort-output/--ignore-kilosort-output",
+            "-k/-K",
+            help="Upload Kilosort output (-k) or not (-K).",
+        ),
+    ] = False
 ):
     """
     Download (raw) experimental data from a given session from the remote server.
@@ -386,7 +412,7 @@ def dl(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not include_behavior, not include_ephys, not include_videos]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
         raise ValueError("At least one data type must be included.")
 
     config = _load_config()
@@ -401,6 +427,7 @@ def dl(
         include_videos=include_videos,
         whitelisted_files_in_root=config.WHITELISTED_FILES_IN_ROOT,
         allowed_extensions_not_in_root=config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
+        include_kilosort_output=include_kilosort_output
     )
     print(f"Session {session_name} downloaded.")
 
@@ -519,6 +546,13 @@ def validate_session(
         bool,
         typer.Option("--check-videos/--ignore-videos", help="Check videos data or not."),
     ] = True,
+    check_kilosort_output: Annotated[
+        bool,
+        typer.Option(
+            "--check-kilosort-output/--ignore-kilosort-output",
+            help="Check Kilosort output or not.",
+        ),
+    ] = False
 ):
     """
     Validate experimental data in a given session.
@@ -530,7 +564,7 @@ def validate_session(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not check_behavior, not check_ephys, not check_videos]):
+    if all([not check_behavior, not check_ephys, not check_videos, not check_kilosort_output]):
         raise ValueError("At least one data type must be checked.")
 
     if not session_path.absolute().is_dir():
@@ -548,6 +582,7 @@ def validate_session(
         check_videos,
         config.WHITELISTED_FILES_IN_ROOT,
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
+        check_kilosort_output=check_kilosort_output
     )
 
 
@@ -580,6 +615,13 @@ def validate_last(
         bool,
         typer.Option("--check-videos/--ignore-videos", help="Check videos data or not."),
     ] = True,
+    check_kilosort_output: Annotated[
+        bool,
+        typer.Option(
+            "--check-kilosort-output/--ignore-kilosort-output",
+            help="Check Kilosort output or not.",
+        ),
+    ] = False
 ):
     """
     Validate experimental data in the last session of a subject.
@@ -590,7 +632,7 @@ def validate_last(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not check_behavior, not check_ephys, not check_videos]):
+    if all([not check_behavior, not check_ephys, not check_videos, not check_kilosort_output]):
         raise ValueError("At least one data type must be checked.")
 
     config = _load_config()
@@ -612,6 +654,7 @@ def validate_last(
         check_videos,
         config.WHITELISTED_FILES_IN_ROOT,
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
+        check_kilosort_output=check_kilosort_output
     )
 
 
@@ -750,6 +793,13 @@ def upload_session(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
+    include_kilosort_output: Annotated[
+        bool,
+        typer.Option(
+            "--include-kilosort-output/--ignore-kilosort-output",
+            help="Upload Kilosort output or not.",
+        ),
+    ] = False
 ):
     """
     Upload (raw) experimental data in a given session to the remote server.
@@ -760,7 +810,7 @@ def upload_session(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not include_behavior, not include_ephys, not include_videos]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
         raise ValueError("At least one data type must be included.")
 
     # if videos are included, rename them first if not specified otherwise
@@ -787,6 +837,7 @@ def upload_session(
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
         rename_videos_first,
         rename_extra_files_first,
+        include_kilosort_output=include_kilosort_output
     )
 
     return True
@@ -845,6 +896,14 @@ def up(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
+    include_kilosort_output: Annotated[
+        bool,
+        typer.Option(
+            "--include-kilosort-output/--ignore-kilosort-output",
+            "-k/-K",
+            help="Upload Kilosort output (-k) or not (-K).",
+        ),
+    ] = False
 ):
     """
     Upload (raw) experimental data to the remote server.
@@ -859,7 +918,7 @@ def up(
     if processing_level != "raw":
         raise NotImplementedError("Sorry, only raw data is supported for now.")
 
-    if all([not include_behavior, not include_ephys, not include_videos]):
+    if all([not include_behavior, not include_ephys, not include_videos, not include_kilosort_output]):
         raise ValueError("At least one data type must be included.")
 
     # if videos are included, rename them first if not specified otherwise
@@ -887,6 +946,7 @@ def up(
             config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
             rename_videos_first,
             rename_extra_files_first,
+            include_kilosort_output=include_kilosort_output
         )
         message = f"Session {session_or_animal_name} uploaded."
     else:  # only animal name is given
@@ -899,6 +959,7 @@ def up(
             rename_videos_first,
             rename_extra_files_first,
             processing_level,
+            include_kilosort_output=include_kilosort_output
         )
         message = f"Last session of {animal} uploaded."
     if up_done:
@@ -958,6 +1019,14 @@ def upload_last(
     processing_level: Annotated[
         str, typer.Argument(help="Processing level of the session. raw or processed.")
     ] = "raw",
+    include_kilosort_output: Annotated[
+        bool,
+        typer.Option(
+            "--include-kilosort-output/--ignore-kilosort-output",
+            "-k/-K",
+            help="Upload Kilosort output (-k) or not (-K).",
+        ),
+    ] = None
 ):
     """
     Upload (raw) experimental data in the last session of a subject to the remote server.
@@ -989,6 +1058,8 @@ def upload_last(
         include_ephys = typer.confirm("Include ephys?")
     if include_videos is None:
         include_videos = typer.confirm("Include videos?")
+    if include_kilosort_output is None:
+        include_kilosort_output = typer.confirm("Include Kilosort output?")
 
     if all([not include_behavior, not include_ephys, not include_videos]):
         raise ValueError("At least one data type must be included.")
@@ -1015,6 +1086,7 @@ def upload_last(
         config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
         rename_videos_first,
         rename_extra_files_first,
+        include_kilosort_output=include_kilosort_output
     )
 
     return True

--- a/src/beneuro_data/data_transfer.py
+++ b/src/beneuro_data/data_transfer.py
@@ -99,7 +99,7 @@ def upload_raw_session(
 
     # TODO maybe check separately to have the option to upload things that are valid
     # check everything we want to upload
-    behavior_files, ephys_files, video_files = validate_raw_session(
+    behavior_files, ephys_files, video_files, kilosort_files = validate_raw_session(
         local_session_path,
         subject_name,
         include_behavior,
@@ -142,10 +142,10 @@ def upload_raw_session(
             allowed_extensions_not_in_root,
         )
 
+
     if include_kilosort:
         upload_kilosort(
             local_session_path,
-            subject_name,
             local_root,
             remote_root,
         )
@@ -392,12 +392,11 @@ def upload_extra_files(
 
 def upload_kilosort(
     local_session_path: Path,
-    subject_name: str,
     local_root: Path,
     remote_root: Path,
 ) -> bool:
     # Implement logic to upload Kilosort output
-    kilosort_files = validate_kilosort(local_session_path, subject_name)
+    kilosort_files = validate_kilosort(local_session_path)
     remote_kilosort_files = _source_to_dest(kilosort_files, local_root, remote_root)
     _copy_list_of_files(kilosort_files, remote_kilosort_files, if_exists="error_if_different")
     return True

--- a/src/beneuro_data/data_transfer.py
+++ b/src/beneuro_data/data_transfer.py
@@ -107,6 +107,7 @@ def upload_raw_session(
         include_videos,
         whitelisted_files_in_root,
         allowed_extensions_not_in_root,
+        include_kilosort=include_kilosort
     )
 
     if include_behavior:
@@ -141,7 +142,6 @@ def upload_raw_session(
             whitelisted_files_in_root,
             allowed_extensions_not_in_root,
         )
-
 
     if include_kilosort:
         upload_kilosort(

--- a/src/beneuro_data/data_validation.py
+++ b/src/beneuro_data/data_validation.py
@@ -22,7 +22,7 @@ def validate_raw_session(
     include_videos: bool,
     whitelisted_files_in_root: tuple[str, ...],
     allowed_extensions_not_in_root: tuple[str, ...],
-    include_kilosort_output: bool = False,
+    include_kilosort: bool = False,
 ):
     """
     Validate the files of a raw session.
@@ -45,7 +45,7 @@ def validate_raw_session(
         A tuple of file extensions that are allowed in the session directory excluding the root level.
         E.g. (".txt", )
         For what's allowed in the root, use `whitelisted_files_in_root`.
-    include_kilosort_output : bool, default: False
+    include_kilosort : bool, default: False
         Whether to upload the Kilosort output.
 
     Returns
@@ -68,9 +68,9 @@ def validate_raw_session(
         )
     if include_videos:
         video_files = validate_raw_videos_of_session(session_path, subject_name)
-    if include_kilosort_output:
-        kilosort_files = validate_kilosort_output(session_path, subject_name)
-        
+    if include_kilosort:
+        kilosort_files = validate_kilosort(session_path, subject_name)
+
     
 
     return behavior_files, ephys_files, video_files
@@ -521,7 +521,7 @@ def validate_raw_videos_of_session(
     return []
 
 
-def validate_kilosort_output(session_path: Path, subject_name: str) -> list[Path]:
+def validate_kilosort(session_path: Path, subject_name: str) -> list[Path]:
     kilosort_files = []
     # Handle both possible folder structures
     # Structure 1

--- a/src/beneuro_data/data_validation.py
+++ b/src/beneuro_data/data_validation.py
@@ -57,6 +57,7 @@ def validate_raw_session(
     behavior_files = []
     ephys_files = []
     video_files = []
+    kilosort_files = []
 
     if include_behavior:
         behavior_files = validate_raw_behavioral_data_of_session(
@@ -69,11 +70,11 @@ def validate_raw_session(
     if include_videos:
         video_files = validate_raw_videos_of_session(session_path, subject_name)
     if include_kilosort:
-        kilosort_files = validate_kilosort(session_path, subject_name)
+        kilosort_files = validate_kilosort(session_path)
 
     
 
-    return behavior_files, ephys_files, video_files
+    return behavior_files, ephys_files, video_files, kilosort_files
 
 
 def validate_date_format(extracted_date_str: str) -> bool:
@@ -522,7 +523,7 @@ def validate_raw_videos_of_session(
     return []
 
 
-def validate_kilosort(session_path: Path, subject_name: str) -> list[Path]:
+def validate_kilosort(session_path: Path) -> list[Path]:
     kilosort_files = []
     # Handle both possible folder structures
     # Structure 1
@@ -543,6 +544,7 @@ def validate_kilosort(session_path: Path, subject_name: str) -> list[Path]:
                 kilosort_folder = imec_folder / "Kilosort"
                 if kilosort_folder.exists():
                     kilosort_files.extend(kilosort_folder.glob("**/*"))
-    if not kilosort_files:
+
+    if len(kilosort_files) == 0:
         raise FileNotFoundError("No Kilosort output found.")
     return kilosort_files

--- a/src/beneuro_data/data_validation.py
+++ b/src/beneuro_data/data_validation.py
@@ -405,10 +405,11 @@ def validate_raw_ephys_recording(
         expected_filenames = {
             f"{gid_folder_path.name}_t0.{imec_str}{ending}" for ending in expected_endings
         }
-        found_filenames = {p.name for p in probe_folder.iterdir()}
-        if found_filenames != expected_filenames:
+        # Only include files in found_filenames
+        found_filenames = {p.name for p in probe_folder.iterdir() if p.is_file()}
+        if not expected_filenames.issubset(found_filenames):
             raise ValueError(
-                f"Files in probe directory do not match the expected pattern. {probe_folder}"
+                f"Expected files not found in probe directory: {probe_folder}"
             )
 
     return True

--- a/tests/download_raw_session_test_yamls/M011_with_kilosort.yaml
+++ b/tests/download_raw_session_test_yamls/M011_with_kilosort.yaml
@@ -1,0 +1,53 @@
+type: folder
+name: M011
+children:
+- type: folder
+  name: M011_2023_04_04_16_00
+  children:
+  - type: folder
+    name: M011_2023_04_04_16_00_cameras
+    children:
+    - type: file
+      name: M011_2023_04_04_16_00_camera_1.avi
+    - type: file
+      name: M011_2023_04_04_16_00_camera_2.avi
+    - type: file
+      name: M011_2023_04_04_16_00_camera_3.avi
+    - type: file
+      name: metadata.csv
+  - type: file
+    name: M011_2023_04_04_16_00_MotSen1-X.pca
+  - type: file
+    name: M011_2023_04_04_16_00_MotSen1-Y.pca
+  - type: file
+    name: M011_2023_04_04_16_00.txt
+  - type: folder
+    name: M011_2023_04_04_16_00_g1
+    children:
+    - type: folder
+      name: M011_2023_04_04_16_00_g1_imec0
+      children:
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.lf.meta
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.ap.meta
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.lf.bin
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.ap.bin
+      - type: folder
+        name: Kilosort
+        children:
+        - type: file
+          name: spike_times.npy
+        - type: file
+          name: spike_clusters.npy
+        - type: file
+          name: cluster_info.tsv
+        - type: file
+          name: params.py
+  - type: folder
+    name: run_task-task_files
+    children:
+    - type: file
+      name: whatever_task.py

--- a/tests/download_raw_session_test_yamls/M011_without_kilosort.yaml
+++ b/tests/download_raw_session_test_yamls/M011_without_kilosort.yaml
@@ -1,0 +1,42 @@
+type: folder
+name: M011
+children:
+- type: folder
+  name: M011_2023_04_04_16_00
+  children:
+  - type: folder
+    name: M011_2023_04_04_16_00_cameras
+    children:
+    - type: file
+      name: M011_2023_04_04_16_00_camera_1.avi
+    - type: file
+      name: M011_2023_04_04_16_00_camera_2.avi
+    - type: file
+      name: M011_2023_04_04_16_00_camera_3.avi
+    - type: file
+      name: metadata.csv
+  - type: file
+    name: M011_2023_04_04_16_00_MotSen1-X.pca
+  - type: file
+    name: M011_2023_04_04_16_00_MotSen1-Y.pca
+  - type: file
+    name: M011_2023_04_04_16_00.txt
+  - type: folder
+    name: M011_2023_04_04_16_00_g1
+    children:
+    - type: folder
+      name: M011_2023_04_04_16_00_g1_imec0
+      children:
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.lf.meta
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.ap.meta
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.lf.bin
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.ap.bin
+  - type: folder
+    name: run_task-task_files
+    children:
+    - type: file
+      name: whatever_task.py

--- a/tests/test_data_transfer.py
+++ b/tests/test_data_transfer.py
@@ -529,4 +529,5 @@ def test_upload_raw_session(tmp_path, test_case: RawSessionUploadTestCase):
                 EXTENSIONS_TO_RENAME_AND_UPLOAD,
                 test_case.rename_videos_first,
                 test_case.rename_extra_files_first,
+                include_kilosort=test_case.include_kilosort
             )

--- a/tests/test_data_transfer.py
+++ b/tests/test_data_transfer.py
@@ -163,6 +163,7 @@ class RawSessionUploadTestCase:
     include_videos: bool
     rename_videos_first: bool
     rename_extra_files_first: bool
+    include_kilosort: bool = False
 
     @property
     def mouse_name(self) -> str:
@@ -293,6 +294,32 @@ raw_session_upload_test_cases_without_renaming_first = [
         True,
         False,
         False,
+    ),
+    # with kilosort output
+    RawSessionUploadTestCase(
+    yaml_name="M011_with_kilosort.yaml",
+    session_name="M011_2023_04_04_16_00",
+    expected_error=None,
+    error_message=None,
+    include_behavior=True,
+    include_ephys=True,
+    include_videos=True,
+    rename_videos_first=False,
+    rename_extra_files_first=False,
+    include_kilosort=True,
+    ),
+    # without kilosort output
+    RawSessionUploadTestCase(
+        yaml_name="M011_without_kilosort.yaml",
+        session_name="M011_2023_04_04_16_00",
+        expected_error=FileNotFoundError,
+        error_message="No Kilosort output found.",
+        include_behavior=True,
+        include_ephys=True,
+        include_videos=True,
+        rename_videos_first=False,
+        rename_extra_files_first=False,
+        include_kilosort=True,
     ),
 ]
 
@@ -477,6 +504,7 @@ def test_upload_raw_session(tmp_path, test_case: RawSessionUploadTestCase):
             EXTENSIONS_TO_RENAME_AND_UPLOAD,
             test_case.rename_videos_first,
             test_case.rename_extra_files_first,
+            include_kilosort=test_case.include_kilosort
         )
 
         import filecmp

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -26,6 +26,7 @@ class RawSessionDownloadTestCase:
     include_behavior: bool
     include_ephys: bool
     include_videos: bool
+    include_kilosort: bool = False
 
     @property
     def mouse_name(self) -> str:
@@ -90,6 +91,29 @@ session_download_test_cases = [
     #    True,
     #    True,
     # ),
+    # with kilosort
+    RawSessionDownloadTestCase(
+    yaml_name="M011_with_kilosort.yaml",
+    session_name="M011_2023_04_04_16_00",
+    expected_error=None,
+    error_message=None,
+    include_behavior=True,
+    include_ephys=True,
+    include_videos=True,
+    include_kilosort=True,
+    ),
+    # without kilosort
+    RawSessionDownloadTestCase(
+        yaml_name="M011_without_kilosort.yaml",
+        session_name="M011_2023_04_04_16_00",
+        expected_error=FileNotFoundError,
+        error_message="No Kilosort output found.",
+        include_behavior=True,
+        include_ephys=True,
+        include_videos=True,
+        include_kilosort=True,
+    ),
+
 ]
 
 
@@ -126,6 +150,7 @@ def test_download_raw_session(tmp_path, test_case: RawSessionDownloadTestCase):
             test_case.include_videos,
             WHITELISTED_FILES_IN_ROOT,
             EXTENSIONS_TO_RENAME_AND_UPLOAD,
+            include_kilosort = test_case.include_kilosort
         )
 
         import filecmp

--- a/tests/upload_raw_session_test_yamls/M011_with_kilosort.yaml
+++ b/tests/upload_raw_session_test_yamls/M011_with_kilosort.yaml
@@ -1,0 +1,53 @@
+type: folder
+name: M011
+children:
+- type: folder
+  name: M011_2023_04_04_16_00
+  children:
+  - type: folder
+    name: M011_2023_04_04_16_00_cameras
+    children:
+    - type: file
+      name: M011_2023_04_04_16_00_camera_1.avi
+    - type: file
+      name: M011_2023_04_04_16_00_camera_2.avi
+    - type: file
+      name: M011_2023_04_04_16_00_camera_3.avi
+    - type: file
+      name: metadata.csv
+  - type: file
+    name: M011_2023_04_04_16_00_MotSen1-X.pca
+  - type: file
+    name: M011_2023_04_04_16_00_MotSen1-Y.pca
+  - type: file
+    name: M011_2023_04_04_16_00.txt
+  - type: folder
+    name: M011_2023_04_04_16_00_g1
+    children:
+    - type: folder
+      name: M011_2023_04_04_16_00_g1_imec0
+      children:
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.lf.meta
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.ap.meta
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.lf.bin
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.ap.bin
+      - type: folder
+        name: Kilosort
+        children:
+        - type: file
+          name: spike_times.npy
+        - type: file
+          name: spike_clusters.npy
+        - type: file
+          name: cluster_info.tsv
+        - type: file
+          name: params.py
+  - type: folder
+    name: run_task-task_files
+    children:
+    - type: file
+      name: whatever_task.py

--- a/tests/upload_raw_session_test_yamls/M011_without_kilosort.yaml
+++ b/tests/upload_raw_session_test_yamls/M011_without_kilosort.yaml
@@ -1,0 +1,42 @@
+type: folder
+name: M011
+children:
+- type: folder
+  name: M011_2023_04_04_16_00
+  children:
+  - type: folder
+    name: M011_2023_04_04_16_00_cameras
+    children:
+    - type: file
+      name: M011_2023_04_04_16_00_camera_1.avi
+    - type: file
+      name: M011_2023_04_04_16_00_camera_2.avi
+    - type: file
+      name: M011_2023_04_04_16_00_camera_3.avi
+    - type: file
+      name: metadata.csv
+  - type: file
+    name: M011_2023_04_04_16_00_MotSen1-X.pca
+  - type: file
+    name: M011_2023_04_04_16_00_MotSen1-Y.pca
+  - type: file
+    name: M011_2023_04_04_16_00.txt
+  - type: folder
+    name: M011_2023_04_04_16_00_g1
+    children:
+    - type: folder
+      name: M011_2023_04_04_16_00_g1_imec0
+      children:
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.lf.meta
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.ap.meta
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.lf.bin
+      - type: file
+        name: M011_2023_04_04_16_00_g1_t0.imec0.ap.bin
+  - type: folder
+    name: run_task-task_files
+    children:
+    - type: file
+      name: whatever_task.py


### PR DESCRIPTION
This PR adds functionality to include Kilosort output in the data transfer process.
I added include_kilosort arguemnt in data transfer functions and updated validation, command-line commands (e.g. up, dl) accordingly. I also added new test cases for handling kilosort outputs and passed all the tests locally. As we will get rid of processed folder and use only raw folder in the future, kilosort outputs are assumed to be stored in raw folder.