### PR TITLE
fixed validate_raw_session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *.egg-info*
 *.ipynb
+.idea/

--- a/src/beneuro_data/cli.py
+++ b/src/beneuro_data/cli.py
@@ -1131,6 +1131,13 @@ def validate_sessions(
             help="Rename extra files (e.g. comment.txt) before validating and uploading.",
         ),
     ] = True,
+    check_kilosort: Annotated[
+        bool,
+        typer.Option(
+            "--check-kilosort-output/--ignore-kilosort-output",
+            help="Check Kilosort output or not.",
+        ),
+    ] = False
 ):
     """
     Validate (raw) experimental data in all sessions of a given subject.
@@ -1162,6 +1169,7 @@ def validate_sessions(
                     config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
                     rename_videos_first,
                     rename_extra_files_first,
+                    check_kilosort=check_kilosort
                 )
             except Exception as e:
                 print(f"[bold red]Problem with {session_path.name}: {e.args[0]}\n")
@@ -1227,6 +1235,13 @@ def validate_today(
         bool,
         typer.Option("--check-videos/--ignore-videos", help="Check videos data or not."),
     ] = True,
+    check_kilosort: Annotated[
+        bool,
+        typer.Option(
+            "--check-kilosort-output/--ignore-kilosort-output",
+            help="Check Kilosort output or not.",
+        ),
+    ] = False
 ):
     """
     Validate all sessions of all subjects that happened today.
@@ -1260,6 +1275,7 @@ def validate_today(
                     check_videos,
                     config.WHITELISTED_FILES_IN_ROOT,
                     config.EXTENSIONS_TO_RENAME_AND_UPLOAD,
+                    check_kilosort=check_kilosort
                 )
             except Exception as e:
                 print(f"[bold red]Problem with {session_path.name}: {e.args[0]}\n")

--- a/src/beneuro_data/conversion/convert_to_nwb.py
+++ b/src/beneuro_data/conversion/convert_to_nwb.py
@@ -113,7 +113,7 @@ def convert_to_nwb(
         raise ValueError(f"{raw_session_path} is not in {base_path / 'raw'}")
 
     # validate session before doing any conversion
-    _, ephys_files, _ = validate_raw_session(
+    _, ephys_files, _, _ = validate_raw_session(
         raw_session_path,
         subject_name,
         include_behavior=True,

--- a/src/beneuro_data/data_validation.py
+++ b/src/beneuro_data/data_validation.py
@@ -72,8 +72,6 @@ def validate_raw_session(
     if include_kilosort:
         kilosort_files = validate_kilosort(session_path)
 
-    
-
     return behavior_files, ephys_files, video_files, kilosort_files
 
 
@@ -409,9 +407,7 @@ def validate_raw_ephys_recording(
         # Only include files in found_filenames
         found_filenames = {p.name for p in probe_folder.iterdir() if p.is_file()}
         if not expected_filenames.issubset(found_filenames):
-            raise ValueError(
-                f"Expected files not found in probe directory: {probe_folder}"
-            )
+            raise ValueError(f"Expected files not found in probe directory: {probe_folder}")
 
     return True
 


### PR DESCRIPTION
This PR fixes an issue with the validate_raw_session. validate_raw_session now returns 4 outputs including kilosort_files, but in convert_to_nwb.py, the code was not updated and expected to receive 3 outputs, which was causing an error. I also realized that I forgot to update some validation methods to get check_kilosort argument, and I fixed that too.